### PR TITLE
Checked with latest WP Version.

### DIFF
--- a/jobpress.php
+++ b/jobpress.php
@@ -3,7 +3,7 @@
 Plugin Name: JobPress
 Plugin URI: https://wordpress.org/plugins/jobpress/
 Description: JobPress is the ultimate WordPress job board plugin for a company. It is designed & developed to build your company own job board and career page by few clicks.
-Version: 2.1.5
+Version: 2.1.6
 Author: Aminur Islam Arnob
 Author URI: https://aiarnob.com/
 License: GPLv2 or later
@@ -20,7 +20,7 @@ if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
 
 // Define Version.
 if ( ! defined( 'JOBPRESS_VERSION' ) ) {
-	define( 'JOBPRESS_VERSION', '2.1.5' );
+	define( 'JOBPRESS_VERSION', '2.1.6' );
 }
 
 // Define CONSTANTS

--- a/jobpress.php
+++ b/jobpress.php
@@ -3,7 +3,7 @@
 Plugin Name: JobPress
 Plugin URI: https://wordpress.org/plugins/jobpress/
 Description: JobPress is the ultimate WordPress job board plugin for a company. It is designed & developed to build your company own job board and career page by few clicks.
-Version: 2.1.4
+Version: 2.1.5
 Author: Aminur Islam Arnob
 Author URI: https://aiarnob.com/
 License: GPLv2 or later
@@ -20,7 +20,7 @@ if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
 
 // Define Version.
 if ( ! defined( 'JOBPRESS_VERSION' ) ) {
-	define( 'JOBPRESS_VERSION', '2.1.4' );
+	define( 'JOBPRESS_VERSION', '2.1.5' );
 }
 
 // Define CONSTANTS

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: jobpress, job board, careers, job listing, job manager, job portal, job op
 Requires at least: 5.6
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.1.5
+Stable tag: 2.1.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -147,7 +147,7 @@ Example with all attributes:
 
 == Changelog ==
 
-= v2.1.5 (Dec 24, 2025)  =
+= v2.1.5 & v2.1.6 (Dec 24, 2025)  =
 * Compatibility check with latest WordPress Version v6.9
 
 = v2.1.4 (Aug 24, 2025)  =

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,6 @@
 === JobPress - Your Company Job Board & Career Page ===
 Contributors: aminurislam01
+Donate link: https://www.buymeacoffee.com/aiarnob
 Tags: jobpress, job board, careers, job listing, job manager, job portal, job openings, jobs
 Requires at least: 5.6
 Tested up to: 6.9

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: aminurislam01
 Tags: jobpress, job board, careers, job listing, job manager, job portal, job openings, jobs
 Requires at least: 5.6
-Tested up to: 6.8.2
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.1.4
+Stable tag: 2.1.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,9 @@ JobPress includes a **dedicated Elementor Addon** to display job lists without s
 From the WordPress Admin Bar, you’ll get **quick access** to:
 * Job Archive / Default Job Listing Page
 * JobPress settings
+
+== Support ==
+If you find this plugin useful, consider supporting its development through a [donation](https://www.buymeacoffee.com/aiarnob).
 
 == Installation ==
 
@@ -142,6 +145,9 @@ Example with all attributes:
 ```
 
 == Changelog ==
+
+= v2.1.5 (Dec 24, 2025)  =
+* Compatibility check with latest WordPress Version v6.9
 
 = v2.1.4 (Aug 24, 2025)  =
 * **Update:** Added plugin setup and configuration quick guideline in documentation.

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -14,10 +14,7 @@ if (PHP_VERSION_ID < 50600) {
             echo $err;
         }
     }
-    trigger_error(
-        $err,
-        E_USER_ERROR
-    );
+    throw new RuntimeException($err);
 }
 
 require_once __DIR__ . '/composer/autoload_real.php';

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInit0eb39e4ba6dba87cbf080b7009d02205
 {
     public static $prefixLengthsPsr4 = array (
-        'J' => 
+        'J' =>
         array (
             'JobPressInc\\' => 12,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'JobPressInc\\' => 
+        'JobPressInc\\' =>
         array (
             0 => __DIR__ . '/../..' . '/inc',
         ),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'aminurislam/plugin-starter-pack',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '1966fee55e5ea2f4ee5e96229adc3460ac26177b',
+        'reference' => '72f5d6c104d4a9f67163a1e408a990d709ce78a9',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'aminurislam/plugin-starter-pack' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '1966fee55e5ea2f4ee5e96229adc3460ac26177b',
+            'reference' => '72f5d6c104d4a9f67163a1e408a990d709ce78a9',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates plugin versioning and metadata for a new release, plus refreshes Composer-generated files.
> 
> - Bump version to `2.1.6` in `jobpress.php` and `JOBPRESS_VERSION`
> - Readme updates: `Tested up to: 6.9`, `Stable tag: 2.1.6`, added donate link, new **Support** section, and changelog entries for `v2.1.5`/`v2.1.6`
> - Composer vendor changes: `vendor/autoload.php` now throws `RuntimeException` instead of `trigger_error`; `Composer\InstalledVersions` gains duplicate-protection improvements and self-dir tracking; updated `installed.php` references and minor autoload formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c38946458a564b43c8d4bf5c487dce449ca4dc66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->